### PR TITLE
Update URL to metacpan.org

### DIFF
--- a/lib/App/CPANtoRPM.pm
+++ b/lib/App/CPANtoRPM.pm
@@ -260,7 +260,7 @@ sub _args {
 #   disttag    => %{?dist}
 #   epoch      =>                        The epoch number (set by --epoch)
 #   group      => Development/Libraries
-#   url        => http://search.cpan.org/dist/Foo-Bar/
+#   url        => https://metacpan.org/dist/Foo-Bar/
 #   license    => GPL+ or Artistic
 #   source     => http://www.cpan.org/authors/id/S/SB/SBECK/Foo-Bar-1.0.tar.gz
 #   packager   => PACKAGER
@@ -1474,7 +1474,7 @@ sub _make_spec {
    $package{'disttag'} = $$self{'disttag'};
    $package{'url'}     = ($package{'from'} eq 'url' ?
                           $package{'fromsrc'} :
-                          "http://search.cpan.org/dist/$package{name}/");
+                          "https://metacpan.org/dist/$package{name}");
    $package{'epoch'}   = $$self{'epoch'}  if ($$self{'epoch'} ne '');
    $package{'group'}   = $$self{'group'};
    $package{'license'} = ($package{'m_license'} ?


### PR DESCRIPTION
Seems like the URL update didn't quite really make it into v1.13. Until a command-line parameter is provided, you can use this commit.
One place remaining - "$package{'source'}", but I didn't want to experiment with that.
(P.S. Yes, it's me who suggested it via mail in the first place - Hi again! :) ).